### PR TITLE
update key vault sku resource block to sku_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,7 @@ resource "azurerm_key_vault" "kv" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
-  sku {
-    name = "${var.sku}"
-  }
+  sku_name "${var.sku}"
 
   tenant_id = "${var.tenant_id}"
 


### PR DESCRIPTION
Resolves #

When using this module, the following errors are returned:

Error: Missing required argument

  on .terraform/modules/KeyVault/main.tf line 5, in resource "azurerm_key_vault" "kv":
   5: resource "azurerm_key_vault" "kv" {

The argument "sku_name" is required, but no definition was found.

Error: Unsupported block type

  on .terraform/modules/KeyVault/main.tf line 10, in resource "azurerm_key_vault" "kv":
  10:   sku {

Blocks of type "sku" are not expected here.


Notes:
The terraform resource requires the attribute "sku_name" to be specified, but the module resource does not have this defined.