### PR TITLE
fix: incompability with v2 - sku_name vs sku

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,8 @@ resource "azurerm_key_vault" "kv" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
-  sku {
-    name = "${var.sku}"
-  }
+  sku_name = var.sku
+  
 
   tenant_id = "${var.tenant_id}"
 


### PR DESCRIPTION
* renames sku block to sku_name which seems to be correct (and required) property of new azurerm
https://www.terraform.io/docs/providers/azurerm/r/key_vault.html#sku_name

