### PR TITLE
Update Creator rights for soft-delete feature

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ resource "azurerm_key_vault_access_policy" "creator_access_policy" {
     "list",
     "get",
     "delete",
+    "recover",
   ]
 }
 


### PR DESCRIPTION
Enabling soft-delete feature for key-vaults requires Terraform to use "recover" permissions when kv objects get accidentaly deleted. 
