### PR TITLE
DTSPO-260 Give developers access to secrets in non production

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,27 @@ module "claim-store-vault" {
 }
 ```
 
+## Reading secrets
+
+All developers have access to read non production secrets if they are a member of the `DTS CFT Developers` Azure AD group
+
+Reading of production secrets is discouraged, in general you should overwrite the secret rather than trying to read it.
+
+_If you really really need that secret then ask the Platform Operations team to get it for you._
+
+Reading a secret via Azure CLI:
+```bash
+$ az keyvault secret show --vault-name $VAULT --name $SECRET
+```
+
 ## Writing secrets to key vaults
 The product group for the key vault have permissions to update / write / list / delete secrets in all environments
 This should be your teams AD group, it's controlled by the `product_group_object_id` variable
 
-You should always write secrets via the command line, as you normally don't have read access on the production vault but you can still write the secrets via CLI.
+You should always write secrets via the command line, as you normally don't have read access on the production vault, but you can still write the secrets via CLI.
 
 ```bash
-$ az keyvault secret set --vault-name vault-name --name name --value value
+$ az keyvault secret set --vault-name $VAULT_NAME --name "${SECRET_NAME}" --value "${SECRET_VALUE}"
 ```
 
 More docs can be found here:
@@ -66,7 +79,7 @@ create_managed_identity = true
 Object Id and Client id are available in terraform output.
 
 #### Use an Existing MI
-Add an additional variable to the module (`managed_identity_object_ids`) with existing managed identity.
+Add the `managed_identity_object_ids` variable to the module with an existing managed identity.
 
 ```
 data "azurerm_user_assigned_identity" "cmc-identity" {

--- a/developer-access.tf
+++ b/developer-access.tf
@@ -1,0 +1,30 @@
+data "azuread_group" "developers" {
+  name = var.developers_group
+}
+
+locals {
+  is_prod = length(regexall(".*(prod).*", var.env)) > 0
+}
+
+resource "azurerm_key_vault_access_policy" "developer" {
+  key_vault_id = azurerm_key_vault.kv.id
+  object_id    = data.azuread_group.developers.object_id
+  tenant_id    = var.tenant_id
+
+  key_permissions = [
+    "get",
+    "list",
+  ]
+
+  certificate_permissions = [
+    "get",
+    "list",
+  ]
+
+  secret_permissions = [
+    "get",
+    "list",
+  ]
+
+  count = local.is_prod ? 0 : 1
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,7 @@ variable "create_managed_identity" {
 variable "soft_delete_enabled" {
   default = true
 }
+
+variable "developers_group" {
+  default = "DTS CFT Developers"
+}


### PR DESCRIPTION
After discussing with users the only reason they came back with for why they currently need write access to non production is to add themselves to Key Vaults to read non production secrets for their functional tests.

Discussed with users and Platform Owner, and it was agreed that Developers should have read access to all non prod key vaults so that they can retrieve secrets required for doing functional tests