### PR TITLE
Add purge access for jenkins MI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,5 +58,6 @@ resource "azurerm_key_vault_access_policy" "creator_access_policy" {
     "get",
     "delete",
     "recover",
+    "purge",
   ]
 }


### PR DESCRIPTION
Notes:
* This change is to enable purge access for Jenkins MI, so secrets can be deleted and avoid pipeline failures
*
*
