### PR TITLE
add security_enabled to azuread_group call

### DIFF
--- a/team-access.tf
+++ b/team-access.tf
@@ -1,5 +1,6 @@
 data "azuread_group" "product_team" {
-  display_name = var.product_group_name
+  display_name     = var.product_group_name
+  security_enabled = true
 
   count = var.product_group_name == "" ? 0 : 1
 }


### PR DESCRIPTION
add security_enabled: true to azuread_group to avoid multiple return clash when name specified has both a Microsoft 365 & Security type group