### PR TITLE
Revert "'log' to 'enabled_log' due to depreciation"

### DIFF
--- a/diagnostic-settings.tf
+++ b/diagnostic-settings.tf
@@ -3,7 +3,7 @@ resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
   target_resource_id         = azurerm_key_vault.kv.id
   log_analytics_workspace_id = module.log_analytics_workspace.workspace_id
 
-  enabled_log {
+  log {
     category = "AuditEvent"
 
     retention_policy {


### PR DESCRIPTION
Reverts hmcts/cnp-module-key-vault#55 - errors being hit by other users using module (probably due to older azurerm versions being used)