### PR TITLE
Dtspo 12662 workload identity fed creds

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,10 @@ variable "name" {
 variable "product" {
   description = "(Required) The name of your application"
 }
+variable "namespace" {
+  description = "The namespace of your application"
+  default     = ""
+}
 
 variable "env" {
   description = "(Required)"


### PR DESCRIPTION
Initial commit for https://tools.hmcts.net/jira/browse/DTSPO-12662

This change:
- Adds federated identity credential resource to this key vault module for migration to workload identity

Notes:
* May need different provider for clusters
* May need list functionality added for teams that wish to use another teams identity
* Will need testing with cluster rebuilds and how the `issuer_url` behaves
