### PR TITLE
Fix deprecation: Switch log to enabled_log

### DIFF
--- a/diagnostic-settings.tf
+++ b/diagnostic-settings.tf
@@ -3,7 +3,7 @@ resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
   target_resource_id         = azurerm_key_vault.kv.id
   log_analytics_workspace_id = module.log_analytics_workspace.workspace_id
 
-  log {
+  enabled_log {
     category = "AuditEvent"
 
     retention_policy {


### PR DESCRIPTION
```
[2023-07-19T08:44:01.452Z] │ Warning: Argument is deprecated
[2023-07-19T08:44:01.452Z] │ 
[2023-07-19T08:44:01.452Z] │   with module.key-vault.azurerm_monitor_diagnostic_setting.kv-ds,
[2023-07-19T08:44:01.452Z] │   on .terraform/modules/key-vault/diagnostic-settings.tf line 1, in resource "azurerm_monitor_diagnostic_setting" "kv-ds":
[2023-07-19T08:44:01.452Z] │    1: resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
[2023-07-19T08:44:01.452Z] │ 
[2023-07-19T08:44:01.452Z] │ `log` has been superseded by `enabled_log` and will be removed in version
[2023-07-19T08:44:01.452Z] │ 4.0 of the AzureRM Provider.
```