### PR TITLE
Add new key perm for creator access policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ resource "azurerm_key_vault_access_policy" "creator_access_policy" {
     "WrapKey",
     "Sign",
     "Verify",
+    "GetRotationPolicy",
   ]
 
   secret_permissions = [


### PR DESCRIPTION
Notes:
* since upgrading the provider version for azurerm, my builds have failed due to the jenkins mi not having this permission. eg https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS%2Fpre-shared-infrastructure/detail/perftest/13/pipeline/
* 