### PR TITLE
fix: remove retention_policy from diagnostic setting as it is deprecated

### DIFF
--- a/diagnostic-settings.tf
+++ b/diagnostic-settings.tf
@@ -5,11 +5,6 @@ resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
 
   enabled_log {
     category = "AuditEvent"
-
-    retention_policy {
-      enabled = true
-      days    = 14
-    }
   }
 }
 


### PR DESCRIPTION
You can no longer create a diagnostic setting for a log workspace with a retention policy. This now needs to be managed separately https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy