### PR TITLE
Local idam ENV conversion

### DIFF
--- a/managed-identity.tf
+++ b/managed-identity.tf
@@ -1,13 +1,14 @@
 locals {
   managed_identity_list = toset(compact(concat(var.managed_identity_object_ids, [var.managed_identity_object_id])))
+  env = replace(var.env, "idam-", "")
 }
 
 resource "azurerm_user_assigned_identity" "managed_identity" {
 
-  resource_group_name = "managed-identities-${var.env}-rg"
+  resource_group_name = "managed-identities-${local.env}-rg"
   location            = var.location
 
-  name = "${var.product}-${var.env}-mi"
+  name = "${var.product}-${local.env}-mi"
 
   tags  = var.common_tags
   count = var.create_managed_identity ? 1 : 0

--- a/managed-identity.tf
+++ b/managed-identity.tf
@@ -1,6 +1,6 @@
 locals {
   managed_identity_list = toset(compact(concat(var.managed_identity_object_ids, [var.managed_identity_object_id])))
-  env = replace(var.env, "idam-", "")
+  env                   = replace(var.env, "idam-", "")
 }
 
 resource "azurerm_user_assigned_identity" "managed_identity" {


### PR DESCRIPTION
IDAM envs are prepended with `idam-` which leads to issues when handling their resources in this module when implementing the addition of `create_managed_identity` -- https://github.com/hmcts/idam-shared-infrastructure/pull/98/files

Similar done in https://github.com/hmcts/terraform-module-postgresql-flexible/pull/43/files

Stops resource group not existing when making identity - doesn't affect existing resources as nothing is replaced if the env does not contain idam


Notes:
*
*
*
