### PR TITLE
fix: added metrics block

### DIFF
--- a/diagnostic-settings.tf
+++ b/diagnostic-settings.tf
@@ -7,14 +7,10 @@ resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
     category = "AuditEvent"
   }
 
-  metric {
-    category = "AllMetrics"
-    enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
+  lifecycle {
+    ignore_changes = [
+      metric,
+    ]
   }
 }
 

--- a/diagnostic-settings.tf
+++ b/diagnostic-settings.tf
@@ -6,6 +6,16 @@ resource "azurerm_monitor_diagnostic_setting" "kv-ds" {
   enabled_log {
     category = "AuditEvent"
   }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
 }
 
 module "log_analytics_workspace" {


### PR DESCRIPTION
Added `metrics` block to `azurerm_monitor_diagnostic_setting`, this appears to being set by a policy deployment. This implementation stops terraform from wiping it out every time it runs & cleans up plans.